### PR TITLE
chore: add well-known config for Element EMS

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -1,0 +1,8 @@
+{
+    "m.homeserver": {
+        "base_url": "https://ipfs.ems.host"
+    },
+    "m.identity_server": {
+        "base_url": "https://vector.im"
+    }
+} 

--- a/static/.well-known/matrix/server
+++ b/static/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+    "m.server": "ipfs.ems.host:443"
+} 


### PR DESCRIPTION
Closes #2

Ref:
@andyschwab 

> This ensures our Matrix rooms are reachable from the federated network (so typing roomname:ipfs.io works from any client).
