### PR TITLE
Fix: replace text that prettier ate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://img.shields.io/badge/framework-Nuxt-green.svg)](https://nuxtjs.org/)
 [![](https://img.shields.io/badge/deployed%20on-Fleek-ff69b4.svg)](http://fleek.co/)
 
-![Image of IPFS blog displayed on a laptop](https://user-images.githubusercontent.com/1507828/121082054-c3df1480-c79a-11eb-89f0-681f41ec705c.png)
+![Image of IPFS website displayed on a laptop](https://user-images.githubusercontent.com/1507828/121082054-c3df1480-c79a-11eb-89f0-681f41ec705c.png)
 
 **This repository contains code and content for the [official IPFS Project website](https://ipfs.io)**, located at https://ipfs.io. This site acts as a high-level overview of the IPFS project, offering valuable introductory information and next-steps pathways for prospective and current IPFS users and developers, members of the press, and more.
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -79,8 +79,8 @@
               "
             />
             before it's gone forever. It's not good enough for the medium of our
-            era to be this fragile. IPFS keeps every version of and makes it
-            simple to set up resilient networks for mirroring data.
+            era to be this fragile. IPFS keeps every version of your files and
+            makes it simple to set up resilient networks for mirroring data.
           </p>
         </div>
         <div>
@@ -207,7 +207,7 @@
               All IPFS, no frills
             </h5>
             <p class="mb-4">
-              Just want IPFS in your terminal? Get step-by-step instructions
+              Just want IPFS in your terminal? Get step-by-step instructions for
               getting up and running on the command line using the Go
               implementation of IPFS. Includes directions for Windows, macOS,
               and Linux.


### PR DESCRIPTION
Looks like prettier ate some homepage text at some point when it reformatted for line lengths. This PR finds and fixes that.