### PR TITLE
fix: improve Twitter social card display

### DIFF
--- a/components/SeoTags.vue
+++ b/components/SeoTags.vue
@@ -28,6 +28,11 @@ export default {
           content: this.description,
         },
         {
+          hid: 'twitter:card',
+          name: 'twitter:card',
+          content: 'summary',
+        },
+        {
           hid: 'twitter:title',
           name: 'twitter:title',
           content: this.title,
@@ -46,6 +51,11 @@ export default {
           hid: 'twitter:image:alt',
           name: 'twitter:image:alt',
           content: this.title,
+        },
+        {
+          hid: 'twitter:site',
+          name: 'twitter:site',
+          content: '@ipfs',
         },
         {
           hid: 'og:title',


### PR DESCRIPTION
This PR adds things: 
`twitter:card` and `twitter:site`
your daily haiku