### PR TITLE
feat: add task completion survey banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2890,6 +2890,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@carsy/task-completion-survey-banner": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@carsy/task-completion-survey-banner/-/task-completion-survey-banner-1.3.0.tgz",
+      "integrity": "sha512-tKewL0l6ZVfrFFMruxs0nAiHyN3k2WaHVoaHUX9ORqKBTrnwmramsfwVwfoIHreKuOjEQkKrV40TtPFjD8TrVA=="
+    },
     "@commitlint/cli": {
       "version": "12.1.4",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-12.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     }
   },
   "dependencies": {
+    "@carsy/task-completion-survey-banner": "^1.3.0",
     "@nuxt/content": "^1.14.0",
     "@nuxtjs/speedcurve": "^1.1.2",
     "@tailwindcss/typography": "^0.4.1",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,10 @@
       title="IPFS Powers the Distributed Web"
       description="The InterPlanetary File System is a peer-to-peer hypermedia protocol designed to preserve and grow humanity's knowledge by making the web upgradeable, resilient, and more open."
     />
-    <StarfieldHero title="IPFS powers the Distributed Web">
+    <StarfieldHero
+      title="IPFS powers the Distributed Web"
+      class="mb-8 sm:mb-28"
+    >
       <h2 class="text-center">
         A peer-to-peer hypermedia protocol
         <br />
@@ -28,7 +31,8 @@
         />
       </div>
     </StarfieldHero>
-    <section id="why" class="grid-margins py-20 sm:py-36">
+    <TaskCompletionSurveyBanner project="ipfs" type="sticky" />
+    <section id="why" class="grid-margins pb-20 sm:pb-36">
       <div class="text-center mb-8 sm:mb-20">
         <h2 class="font-display mb-3">The web of tomorrow needs IPFS today</h2>
         <p class="text-base sm:text-lg">
@@ -980,13 +984,21 @@
 </template>
 
 <script>
+import TaskCompletionSurveyBanner from '@carsy/task-completion-survey-banner/src/index.vue';
+
 import SeoTags from '~/components/SeoTags.vue';
 import Button from '~/components/Button';
 import StarfieldHero from '~/components/StarfieldHero';
 import VideoModal from '~/components/VideoModal.vue';
 
 export default {
-  components: { Button, StarfieldHero, SeoTags, VideoModal },
+  components: {
+    Button,
+    StarfieldHero,
+    SeoTags,
+    VideoModal,
+    TaskCompletionSurveyBanner,
+  },
   data() {
     return {
       latestPosts: [],
@@ -1033,7 +1045,19 @@ export default {
   },
 };
 </script>
+<style>
+#pl--task-completion-survey-banner {
+  display: none;
+}
 
+@media (min-width: 640px) {
+  #pl--task-completion-survey-banner {
+    --max-width: 12rem;
+
+    display: inherit;
+  }
+}
+</style>
 <style scoped>
 .video-preview:hover .video-preview-thumbnail {
   @apply scale-105;


### PR DESCRIPTION
This is the first implementation of the Task Completion Survey banner (package [here](https://github.com/protocol/task-completion-survey-banner))
Let's discuss any changes you might want here.

Current behavior:

- When the user clicks on the close button or the form link CTA, the form will disappear for 30 days (number of days customizable per instance, aka, per website).
    - Let me know if you want me to change it so that when click on the CTA the form will not disappear.
- Data is saved as local storage under the key `pl:task-completion-survey-banner:state`.
    - If you want to test closing it and open again you have to open the site in another browser profile/incognito or another browser. An even easier solution is to clean the application data of the website on the browser, or open the dev tools and on the application tab, select the local storage section and delete the item `pl:task-completion-survey-banner:state` by selecting with the mouse and deleting with the backspace key.
- Banner is currently only being displayed in the homepage. Should it be showing on all the other pages?
- I published the package under my npm user, but I'll try to publish it under the most appropriate org soon. This is not a blocker though.

I don't feel like the UI styles are quite ready, so would appreciate some feedback from @jessicaschilling on this!

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/2353186/127376783-a5ee19d8-9df8-41f8-82f2-a750bb6bc500.png">
