### PR TITLE
fix: redirect ipfs.tech/ipfs → ipfs.io/ipfs

### DIFF
--- a/static/ipfs/ipfs-404.html
+++ b/static/ipfs/ipfs-404.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en-US">
+<head>
+    <script>
+    // if someone tries to open a gateway path on .tech, redirect to .io
+    const { hostname, pathname, href: url } = window.location
+    if (hostname === 'ipfs.tech' && (pathname.startsWith('/ipns/') || pathname.startsWith('/ipfs/'))) {
+      window.location.replace(url.replace('//ipfs.tech/', '//ipfs.io/'))
+    }
+    </script>
+</head>
+<body>
+  <h1>Not a gateway :-)</h1>
+  <p>Try one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
+</body>

--- a/static/ipns/ipfs-404.html
+++ b/static/ipns/ipfs-404.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en-US">
+<head>
+    <script>
+    // if someone tries to open a gateway path on .tech, redirect to .io
+    const { hostname, pathname, href: url } = window.location
+    if (hostname === 'ipfs.tech' && (pathname.startsWith('/ipns/') || pathname.startsWith('/ipfs/'))) {
+      window.location.replace(url.replace('//ipfs.tech/', '//ipfs.io/'))
+    }
+    </script>
+</head>
+<body>
+  <h1>Not a gateway :-)</h1>
+  <p>Try one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
+</body>


### PR DESCRIPTION
> Follow-up for https://github.com/ipfs/ipfs-website/pull/133

Quick hack to fixup folks using ipfs.tech as a gateway for some reason.

As long the user has JS, `location.replace()` will replace the URL in user's browser history with .io one.
If there is no JS, a plain text message is displayed pointing the user at the list of public gateways.