### PR TITLE
fix: remove JS redirect that causes loop

### DIFF
--- a/static/ipfs/ipfs-404.html
+++ b/static/ipfs/ipfs-404.html
@@ -1,14 +1,7 @@
 <!doctype html><html lang="en-US">
 <head>
-    <script>
-    // if someone tries to open a gateway path on .tech, redirect to .io
-    const { hostname, pathname, href: url } = window.location
-    if (hostname === 'ipfs.tech' && (pathname.startsWith('/ipns/') || pathname.startsWith('/ipfs/'))) {
-      window.location.replace(url.replace('//ipfs.tech/', '//ipfs.io/'))
-    }
-    </script>
 </head>
 <body>
   <h1>Not a gateway :-)</h1>
-  <p>Try one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
+  <p>Try loading this path from one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
 </body>

--- a/static/ipns/ipfs-404.html
+++ b/static/ipns/ipfs-404.html
@@ -1,14 +1,7 @@
 <!doctype html><html lang="en-US">
 <head>
-    <script>
-    // if someone tries to open a gateway path on .tech, redirect to .io
-    const { hostname, pathname, href: url } = window.location
-    if (hostname === 'ipfs.tech' && (pathname.startsWith('/ipns/') || pathname.startsWith('/ipfs/'))) {
-      window.location.replace(url.replace('//ipfs.tech/', '//ipfs.io/'))
-    }
-    </script>
 </head>
 <body>
   <h1>Not a gateway :-)</h1>
-  <p>Try one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
+  <p>Try loading this path from one of the <a href="https://ipfs.github.io/public-gateway-checker/">public gateways</a> instead.</p>
 </body>


### PR DESCRIPTION
This should fix https://github.com/protocol/bifrost-infra/issues/2326.

We no longer need these redirects, 
upstream https://github.com/protocol/bifrost-infra/issues/2045 takes care of redirecting main website,
and it is better to explicitly return 404 than  redirecting users back to `ipfs.io`. 