### PR TITLE
feat: link to matrix space

### DIFF
--- a/pages/community.vue
+++ b/pages/community.vue
@@ -32,10 +32,10 @@ definePageMeta({
           </Subhead>
           <div class="mx-auto flex justify-between gap-8">
             <div>
-              <AppLink href="https://filecoin.io/slack">
-                <img src="~/assets/images/circle-slack.svg" class="mx-auto my-4 block">
+              <AppLink href="https://matrix.to/#/#ipfs-space:ipfs.io">
+                <img src="~/assets/images/circle-matrix.svg" class="mx-auto my-4">
                 <p class="text-center text-xl text-black">
-                  Slack
+                  Matrix
                 </p>
               </AppLink>
             </div>
@@ -48,10 +48,10 @@ definePageMeta({
               </AppLink>
             </div>
             <div>
-              <AppLink href="https://matrix.to/#/#lobby:ipfs.io">
-                <img src="~/assets/images/circle-matrix.svg" class="mx-auto my-4">
+              <AppLink href="https://filecoin.io/slack">
+                <img src="~/assets/images/circle-slack.svg" class="mx-auto my-4 block">
                 <p class="text-center text-xl text-black">
-                  Matrix
+                  Slack
                 </p>
               </AppLink>
             </div>


### PR DESCRIPTION
This PR applies cosmetic updates to `/community` page:
-  moves paid Filecoin Slack to the end, and prioritizes IPFS-specific Matrix which is based on open protocols
-  `Matrix` link no longer links to the lobby, but to the "IPFS Space" , which enables discovery of other channels such as `ipfs-help` (see demo below)

### Demo

> What new user sees, when using Element (Matrix client) and clicking on the Matrix link
> ![2023-09-15_19-26](https://github.com/ipfs/ipfs-website/assets/157609/2b9174b1-1b3b-40c2-8dc8-8eea215fe727)
