### PR TITLE
fix(community): video channel

### DIFF
--- a/pages/community.vue
+++ b/pages/community.vue
@@ -93,7 +93,7 @@ definePageMeta({
               newsletter
             </AppLink> and
             <AppLink href="https://www.youtube.com/@IPFSbot/videos">
-              video channel
+              YouTube channel
             </AppLink>.
           </p>
         </Card>

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -91,10 +91,10 @@ definePageMeta({
             Get the latest on news about what's happening in the IPFS ecosystem by
             subscribing to our <AppLink href="https://share.hsforms.com/1-wT-kbwkRw-4HLsYY3nLIgnkivw">
               newsletter
-            </AppLink> or watching
+            </AppLink> and
             <AppLink href="https://www.youtube.com/@IPFSbot/videos">
-              This Month in IPFS
-            </AppLink> livestream.
+              video channel
+            </AppLink>.
           </p>
         </Card>
       </Grid>


### PR DESCRIPTION
This  is a cosmetic change that removes mention of "This Month in IPFS" and just links to "video channel":

> ![2023-09-15_19-40](https://github.com/ipfs/ipfs-website/assets/157609/b25b9052-98eb-4a76-b168-25486e09fa2c)

Linking to channel feels better than linking to something we can't sustain (the last "This Month in IPFS" happened 5 months ago)