### PR TITLE
chore: sunset move the bytes wg

### DIFF
--- a/pages/community.vue
+++ b/pages/community.vue
@@ -188,17 +188,6 @@ definePageMeta({
             </ImageSplit>
             <p>What's covered: Web assembly (Wasm) models, roadmap, community events, feedback.</p>
           </ZebraCard>
-          <ZebraCard cta-label="Meeting Calendar" cta-link="https://lu.ma/8kk9i628" image-class="max-w-30% my-4">
-            <h3>
-              Move the Bytes Working Group
-            </h3>
-            <ImageSplit tight image="constellation-office-hours.svg" image-class="max-w-30% my-4">
-              <p>
-                A working group dedicated to shipping a production-ready data transfer protocol that can replace Bitswap in IPFS.
-              </p>
-            </ImageSplit>
-            <p>What's covered: Roadmap updates, testing, documentation, and tracking metrics.</p>
-          </ZebraCard>
           <ZebraCard cta-label="Meeting Calendar" cta-link="https://lu.ma/ipfs-routing-wg">
             <h3>
               Content Routing Working Group


### PR DESCRIPTION
This PR is part of trying to remove zombies from the website, in this case a card in the middle of  https://ipfs.tech/community/ 

There has been no Move the Bytes WG event [since March 2023](https://www.notion.so/e922e4c54e764496ba3d071018c895bf?v=df1e94a3646e4e11a3775014fd176c98), and various teams in ecosystem already switched or plan to switch from Bitswap to Blocks and DAGs over HTTP (https://specs.ipfs.tech/http-gateways/trustless-gateway/) (or HTTP over Libp2p). 

@b5 are you ok with sunsetting this? Or should we keep it for future use?

