### PR TITLE
fix: better libp2p link on /community page

### DIFF
--- a/pages/community.vue
+++ b/pages/community.vue
@@ -144,7 +144,7 @@ definePageMeta({
             </ImageSplit>
             <p>What’s covered: IPFS improvement proposals (IPIPS), protocol bugs, feedback.</p>
           </ZebraCard>
-          <ZebraCard cta-label="Meeting Calendar" cta-link="https://calendar.google.com/calendar/u/0/embed?src=libp2p.io_0q9682i3te7eanhe9q7ae1c58g@group.calendar.google.com">
+          <ZebraCard cta-label="Learn more" cta-link="https://libp2p.io/#community">
             <h3>
               libp2p Implementers
             </h3>


### PR DESCRIPTION
I think linking to Google Calendar is not the best use of the space.
This PR changes it to "Learn more" and  https://libp2p.io/#community which includes not only info about libp2p calendar, implementers meeting, but also link to discussion forums etc.

 cc  @mxinden if there is a better link libp2p team would like to see at https://ipfs.tech/community/#meetups-wgs