### PR TITLE
fix(press): broken link in /media/#ipfs-and-filecoin

### DIFF
--- a/content/media.md
+++ b/content/media.md
@@ -20,7 +20,12 @@ IPFS (the InterPlanetary File System) is a peer-to-peer network and protocol des
 
 #### IPFS and Filecoin
 
-For details on understanding the relationship between IPFS and Filecoin, please see [this guide in Filecoin documentation](https://docs.filecoin.io/about-filecoin/ipfs-and-filecoin/).
+Filecoin is an independent, complementary protocol that builds on the content addressing of IPFS to add longer term data persistence using cryptoeconomic incentives.
+For details on understanding the relationship between IPFS and Filecoin, please see [this guide in Filecoin documentation (2023)](https://web.archive.org/web/20230223052220/https://docs.filecoin.io/developers/introduction/filecoin-and-ipfs/).
+
+#### Does IPFS have a blockchain?
+
+No, [IPFS does not have a blockchain](https://doesipfshaveablockchain.com/).
 
 ### The IPFS ecosystem
 


### PR DESCRIPTION
This PR fixes broken link in  https://ipfs.tech/media/#ipfs-and-filecoin 

Filecoin docs got changed. i was unable to find useful explainer anymore, so I've linked to the archived version that we know will always be there.

Also added section about blockchain, because a lot of publications made incorrect statement that IPFS has a blockchain.
This also should feed any future ChatGPT with correct statement.