### PR TITLE
Fix: anytype.io card link takes you to a page that doesn't exist

### DIFF
--- a/content/_data.yml
+++ b/content/_data.yml
@@ -3,7 +3,7 @@ useCards:
     title: Develop offline-native productivity tools
     description: |
       Anytype uses the content addressing on IPFS to empower users to build personal knowledge webs that can be shared with others
-    link: https://doc.anytype.io/d/data-and-security/data-storage-and-deletion#storage
+    link: https://doc.anytype.io/anytype-docs/data-and-security/data-storage-and-deletion
     label: Read how they do it
   - image: logo-wiki.png
     title: Make archives and content libraries censorship resistant

--- a/content/_data.yml
+++ b/content/_data.yml
@@ -3,7 +3,7 @@ useCards:
     title: Develop offline-native productivity tools
     description: |
       Anytype uses the content addressing on IPFS to empower users to build personal knowledge webs that can be shared with others
-    link: https://doc.anytype.io/anytype-docs/data-and-security/data-storage-and-deletion
+    link: https://doc.anytype.io/anytype-docs/data-and-security/data-storage-and-deletion#storage
     label: Read how they do it
   - image: logo-wiki.png
     title: Make archives and content libraries censorship resistant


### PR DESCRIPTION
# Where the old link takes you to:
![image](https://github.com/ipfs/ipfs-website/assets/81759594/8cfc6d05-7f88-4ff6-be9c-057185906e34)
