### PR TITLE
remove iroh from IPFS implementations list :(

### DIFF
--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -221,11 +221,6 @@ definePageMeta({
                 </AppLink> (Go) A new, cloud-native IPFS implementation
               </li>
               <li>
-                <AppLink href="https://github.com/n0-computer/iroh">
-                  Iroh
-                </AppLink> (Rust) A new, efficiency-focused implementation of IPFS
-              </li>
-              <li>
                 <AppLink href="https://docs.ipfs.tech/install/ipfs-desktop/">
                   IPFS Desktop
                 </AppLink> Use IPFS on your desktop, with no need to touch the terminal.


### PR DESCRIPTION
I _really_ don't want to file this PR, but after [this exchange on the iroh discord](https://discord.com/channels/1161119546170687619/1161119546644627528/1235211614072868894) it's clear that having iroh listed as an IPFS implementation is a source of confusion, and ultimately we owe it to users to cut down on confusion.

I still very much believe that iroh is an IPFS _system_, but that distinction isn't helping end users. So we have two options to cut down on confusion
1. Commit to doing the work to make iroh & kubo interop.
2. Adjust documentation until user expectations align with what's possible in practical terms.

Our team doesn't have the resources to take on option 1 right now.

cc @mishmosh, @lidel