### PR TITLE
Clarify Iroh description

### DIFF
--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -223,7 +223,7 @@ definePageMeta({
               <li>
                 <AppLink href="https://github.com/n0-computer/iroh">
                   Iroh
-                </AppLink> (Rust) A new, efficiency-focused implementation of IPFS
+                </AppLink> (Rust) An efficiency-focused system for syncing data with CIDs. IPFS-based, but not fully interoperable (see [Iroh docs](https://iroh.computer/docs/ipfs) for details).
               </li>
               <li>
                 <AppLink href="https://docs.ipfs.tech/install/ipfs-desktop/">

--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -223,7 +223,7 @@ definePageMeta({
               <li>
                 <AppLink href="https://github.com/n0-computer/iroh">
                   Iroh
-                </AppLink> (Rust) An efficiency-focused system for syncing data with CIDs. IPFS-based, but not fully interoperable (see [Iroh docs](https://iroh.computer/docs/ipfs) for details).
+                </AppLink> (Rust) An efficiency-focused system for syncing data with CIDs. IPFS-based, but not fully interoperable (see <a href="https://iroh.computer/docs/ipfs">Iroh docs</a> for details).
               </li>
               <li>
                 <AppLink href="https://docs.ipfs.tech/install/ipfs-desktop/">


### PR DESCRIPTION
Following up on the discussion in #312, this clarifies Iroh as an IPFS system but not fully interoperable. If this is approved, we can merge this and close #312. (cc @b5)